### PR TITLE
Add classname to Text

### DIFF
--- a/lib/components/Text/Text.js
+++ b/lib/components/Text/Text.js
@@ -23,15 +23,16 @@ const sizeClasses = {
  * @param {Object} props
  * @prop {String} tag The HTML tag to render the text in
  * @prop {String} size
+ * @prop {String} className
  * @prop {Node} children
  * @return {*}
  */
-const Text = ({ tag, size, children, ...textProps }) => {
+const Text = ({ tag, size, className, children, ...textProps }) => {
   const Tag = tag;
   const tagClass = tag === 'p' ? styles.paragraph : null;
 
   return (
-    <Tag className={cn(sizeClasses[size], tagClass)} {...textProps}>
+    <Tag className={cn(sizeClasses[size], tagClass, className)} {...textProps}>
       {children}
     </Tag>
   );
@@ -40,12 +41,14 @@ const Text = ({ tag, size, children, ...textProps }) => {
 Text.propTypes = {
   tag: PropTypes.string,
   size: PropTypes.oneOf(Object.values(SIZE)),
+  className: PropTypes.string,
   children: PropTypes.node,
 };
 
 Text.defaultProps = {
   tag: 'p',
   size: SIZE.NORMAL,
+  className: undefined,
   children: null,
 };
 


### PR DESCRIPTION
### Proposed Changes

When using text as part of a flex container, if you need to apply a property like flex-grow or something similar, you can't without clobbering the className of this. This allows className to be applied to a text element, instead of having to awkwardly apply it through a parent container

### Checklist

*Place an `x` inside the brackets to check off items.*

- [ ] I have [updated the change log](https://github.com/virtru/dev-guide/blob/master/process/merge-and-tag.md#change-log)
- [ ] I have updated storybook as needed
- [ ] I have updated VRT baselines and included diff images above in "Proposed Changes"
- [ ] I have incremented the package.json and package-lock.json version number
